### PR TITLE
Make it easier to run project container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -L ${GO_URL} | tar -C /opt -xzf - \
     && mkdir -p ${GOPATH}/pkg
 
 VOLUME /data
-VOLUME /etc/pglogger.conf
+VOLUME /etc/pglogger
 
 # Copy & Run pglogger
 COPY *.go ${PROJ_PATH}/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+---
+pgdata:
+  image: debian:jessie
+  volumes:
+    - /data
+  entrypoint: /bin/bash
+  command: -c "sleep infinity"
+
+pglogger:
+  image: mribeiro/pglogger
+  volumes:
+    - ./pglogger.conf:/etc/pglogger/pglogger.conf
+  volumes_from:
+    - pgdata

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	sleepTime  = 2 * time.Second
-	configFile = "/etc/pglogger.conf"
+	configFile = "/etc/pglogger/pglogger.conf"
 )
 
 var log *logrus.Logger


### PR DESCRIPTION
0. Update `Dockerfile` volume to _pglogger_ conf folder (expect a folder not a file).
1. Update reference where _pglogger_ conf is available.
2. Create `docker-compose.yml` spec to start _pglogger_ container.